### PR TITLE
fix: pass module options to Nuxt runtime public config

### DIFF
--- a/playground/app.vue
+++ b/playground/app.vue
@@ -1,20 +1,5 @@
 <template>
-  <PostHogFeatureFlag v-slot="{ payload }" name="test" match="variant">
-    <div>This content is under a feature flag</div>
-    <div
-      v-posthog-capture="{
-        name: 'event',
-        properties: {
-          color: 'red',
-        },
-      }"
-    >
-      This is the feature flag payload: {{ payload }}
-    </div>
-  </PostHogFeatureFlag>
+  <NuxtLayout>
+    <NuxtPage />
+  </NuxtLayout>
 </template>
-
-<script setup lang="ts">
-const runtimeConfig = useRuntimeConfig();
-runtimeConfig.public.posthogApiKey;
-</script>

--- a/playground/layouts/default.vue
+++ b/playground/layouts/default.vue
@@ -1,0 +1,8 @@
+<template>
+  <div>
+    <NuxtLink to="/">/index</NuxtLink>
+    <NuxtLink to="/about">/about</NuxtLink>
+
+    <slot />
+  </div>
+</template>

--- a/playground/pages/about.vue
+++ b/playground/pages/about.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>About</div>
+</template>

--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -1,0 +1,20 @@
+<template>
+  <PostHogFeatureFlag v-slot="{ payload }" name="ab" match="var2">
+    <div>This content is under a feature flag</div>
+    <div
+      v-posthog-capture="{
+        name: 'event',
+        properties: {
+          color: 'red',
+        },
+      }"
+    >
+      This is the feature flag payload: {{ payload }}
+    </div>
+  </PostHogFeatureFlag>
+</template>
+
+<script setup lang="ts">
+const runtimeConfig = useRuntimeConfig();
+runtimeConfig.public.posthogApiKey;
+</script>

--- a/src/module.ts
+++ b/src/module.ts
@@ -60,6 +60,8 @@ export default defineNuxtModule<ModuleOptions>({
       {
         publicKey: options.publicKey,
         host: options.host,
+        capturePageViews: options.capturePageViews,
+        clientOptions: options.clientOptions,
       },
     );
 


### PR DESCRIPTION
Module options were not properly passed to Nuxt's runtime public configuration.