### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@
 
    ```bash
    # Using pnpm
-   pnpm add -D nuxt-posthog
+   npx nuxi@latest module add nuxt-posthog
 
    # Using yarn
-   yarn add --dev nuxt-posthog
+   npx nuxi@latest module add nuxt-posthog
 
    # Using npm
-   npm install --save-dev nuxt-posthog
+   npx nuxi@latest module add nuxt-posthog
    ```
 
 2. Add `nuxt-posthog` to the `modules` section of `nuxt.config.ts`

--- a/docs/content/1.getting-started/2.installation.md
+++ b/docs/content/1.getting-started/2.installation.md
@@ -6,20 +6,9 @@ description: Install the `nuxt-posthog` module using your preferred package mana
 ## Installation
 
 1. Install the `nuxt-posthog` module using your preferred package manager:
-
-::code-group
-```bash [pnpm]
-pnpm add -D nuxt-posthog
+```bash
+npx nuxi@latest module add nuxt-posthog
 ```
-
-```bash [yarn]
-yarn add -D nuxt-posthog
-```
-
-```bash [npm]
-npm install -D nuxt-posthog
-```
-::
 
 2. Add `nuxt-posthog` to your `nuxt-config.ts` file:
 


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
