### PR TITLE
fix(setup): do not show warnings if module is disabled

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -76,10 +76,11 @@ export default defineNuxtModule<ModuleOptions>({
     );
 
     // Make sure url and key are set
-    if (!nuxt.options.runtimeConfig.public.posthog.publicKey) {
+    const enabled = !nuxt.options.runtimeConfig.public.posthog.disabled;
+    if (enabled && !nuxt.options.runtimeConfig.public.posthog.publicKey) {
       console.warn('Missing PostHog API public key, set it either in `nuxt.config.ts` or via env variable');
     }
-    if (!nuxt.options.runtimeConfig.public.posthog.host) {
+    if (enabled && !nuxt.options.runtimeConfig.public.posthog.host) {
       console.warn('Missing PostHog API host, set it either in `nuxt.config.ts` or via env variable');
     }
 


### PR DESCRIPTION
Fixes [comment](https://github.com/mitjans/nuxt-posthog/issues/32#issuecomment-2211788425) in #32 