### PR TITLE
fix: vue compiler warning using `withDefaults` & reactive prop destruture

### DIFF
--- a/src/runtime/components/PostHogFeatureFlag.vue
+++ b/src/runtime/components/PostHogFeatureFlag.vue
@@ -2,13 +2,10 @@
 import { computed } from 'vue';
 import usePostHogFeatureFlag from '../composables/usePostHogFeatureFlag';
 
-const { name } = withDefaults(
-  defineProps<{
-    name: string;
-    match?: boolean | string;
-  }>(),
-  { match: true },
-);
+const { name, match } = defineProps({
+  name: { type: String, required: true },
+  match: { default: true, required: false, type: [String, Boolean] },
+});
 
 const { getFeatureFlag } = usePostHogFeatureFlag();
 


### PR DESCRIPTION
Fixes `@vue/compiler-sfc` warning in `PostHogFeatureFlag`where reactive destructuring is disabled when `withDefaults` is used.

```
Warning: 
[@vue/compiler-sfc] withDefaults() is unnecessary when using destructure with defineProps().
Reactive destructure will be disabled when using withDefaults().
Prefer using destructure default values, e.g. const { foo = 1 } = defineProps(...).

PATH/node_modules/.pnpm/nuxt-posthog@1.5.3_magicast@0.3.5_rollup@4.18.0_webpack-sources@3.2.3/node_modules/nuxt-posthog/dist/runtime/components/PostHogFeatureFlag.vue
3  |  import usePostHogFeatureFlag from '../composables/usePostHogFeatureFlag';
4  |
5  |  const { name } = withDefaults(
   |                   ^^^^^^^^^^^^
6  |    defineProps<{
7  |      name: string;
```

Forced to used runtime types as destructure syntax to set defaults does not work with boolean casting. For example the below will still default to false: 

```
interface Props {
  name: string;
  match?: string | boolean;
}

const { name, match = true } = defineProps<Props>();
```