### PR TITLE
fix: hotfix plugin types

### DIFF
--- a/src/runtime/types/index.d.ts
+++ b/src/runtime/types/index.d.ts
@@ -1,7 +1,24 @@
 import type { ModuleOptions } from '../../module';
+import type { PostHog } from 'posthog-js';
 
 declare module '@nuxt/schema' {
   interface PublicRuntimeConfig {
     posthog: ModuleOptions;
   }
+}
+
+type NuxtPosthogPluginInjections = {
+  $clientPosthog: PostHog | null;
+  $serverPosthog: PostHog | null;
+  $posthog: 'Deprecated: use $clientPosthog instead.';
+};
+
+declare module '#app' {
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+  interface NuxtApp extends NuxtPosthogPluginInjections {}
+}
+
+declare module 'vue' {
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+  interface ComponentCustomProperties extends NuxtPosthogPluginInjections {}
 }


### PR DESCRIPTION
Hotfix for plugin injections returning `unknown` type