### PR TITLE
Send `$pageleave` events using posthog built-in logic

### DIFF
--- a/src/runtime/plugins/posthog.client.ts
+++ b/src/runtime/plugins/posthog.client.ts
@@ -22,7 +22,7 @@ export default defineNuxtPlugin({
     const clientOptions = defu<PostHogConfig, Partial<PostHogConfig>[]>(config.clientOptions ?? {}, {
       api_host: config.host,
       capture_pageview: false,
-      capture_pageleave: config.capturePageLeaves,
+      capture_pageleave: !!config.capturePageLeaves,
       bootstrap: {
         featureFlags: posthogFeatureFlags.value,
         featureFlagPayloads: posthogFeatureFlagPayloads.value,

--- a/src/runtime/plugins/posthog.client.ts
+++ b/src/runtime/plugins/posthog.client.ts
@@ -22,7 +22,7 @@ export default defineNuxtPlugin({
     const clientOptions = defu<PostHogConfig, Partial<PostHogConfig>[]>(config.clientOptions ?? {}, {
       api_host: config.host,
       capture_pageview: false,
-      capture_pageleave: false,
+      capture_pageleave: config.capturePageLeaves,
       bootstrap: {
         featureFlags: posthogFeatureFlags.value,
         featureFlagPayloads: posthogFeatureFlagPayloads.value,
@@ -41,16 +41,6 @@ export default defineNuxtPlugin({
       router.afterEach((to) => {
         posthog.capture('$pageview', {
           current_url: to.fullPath,
-        });
-      });
-    }
-    if (config.capturePageLeaves) {
-      // Make sure that pageleaves are captured with each route change
-      const router = useRouter();
-
-      router.beforeEach((from) => {
-        posthog.capture('$pageleave', {
-          current_url: from.fullPath,
         });
       });
     }


### PR DESCRIPTION
Hey there, I work at posthog and while working on a support ticket I noticed that this library doesn't handle pageleave events correctly.

You're currently sending them on a route change, but this is not how they are intended to be used in an SPA.

To reduce the total number of events required (and therefore to save our customers money), in an SPA we automatically attach the `$pageleave` properties (like `$prev_pageview_duration`) to the following `$pageview` event. This means that on a route change, you only need to send a $pageview event, and it's only required to send a `$pageleave` event when the user fully leaves the SPA (e.g. closes the browser tab, or navigates to a different site).

posthog-js already has code to send the `$pageleave` event when the page closes, so I just changed your library to pass the flag through.

This means that for a session with N pageviews, the user only sends N+1 events, rather than 2xN.