### PR TITLE
dx: vscode eslint setting for ESLint version >= 8.21

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "eslint.experimental.useFlatConfig": true
+  "eslint.useFlatConfig": true
 }


### PR DESCRIPTION
Fix: Use ESLint version 8.57 or later and `eslint.useFlatConfig` instead warning. `experimental` is not needed in the version of `eslint` that `nuxt-posthog` uses (^9.29.0).

Gets rid of the squiggle:
![image](https://github.com/user-attachments/assets/8af8411b-1b48-429d-a70a-aa765e33fd62)
