### PR TITLE
docs: add note about Cloudflare reverse proxy

### DIFF
--- a/docs/content/3.features.md
+++ b/docs/content/3.features.md
@@ -163,3 +163,5 @@ export default defineNuxtConfig({
 ```
 
 This will setup Nuxt route rules as a reverse proxy, following PostHog's [documentation](https://posthog.com/docs/advanced/proxy/nuxt).
+
+If you have multiple projects, are using `nuxi generate`, or a high volume of traffic, consider using a dedicated [Cloudflare reverse proxy](https://posthog.com/docs/advanced/proxy/cloudflare) instead.


### PR DESCRIPTION
The built in method doesn't work when `ssr:false` is set in nuxt.config.ts.

This was helpful for my setup an thought others may benefit from knowing about the Cloudflare option too.