### PR TITLE
Feature (Request): allow customizing the proxyPath

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -70,6 +70,13 @@ export interface ModuleOptions {
    * @docs https://posthog.com/docs/advanced/proxy/nuxt
    */
   proxy?: boolean;
+  /**
+   * The path for the proxy if enabled. The module will create `${proxyPath}/**` and `${proxyPath}/static/**` routes.
+   * @default '/ingest/ph'
+   * @type string
+   * @docs https://posthog.com/docs/advanced/proxy/nuxt
+   */
+  proxyPath?: string;
 }
 
 export default defineNuxtModule<ModuleOptions>({
@@ -84,6 +91,7 @@ export default defineNuxtModule<ModuleOptions>({
     capturePageLeaves: true,
     disabled: false,
     proxy: false,
+    proxyPath: '/ingest/ph',
   },
   setup(options, nuxt) {
     const { resolve } = createResolver(import.meta.url);
@@ -99,6 +107,7 @@ export default defineNuxtModule<ModuleOptions>({
         clientOptions: options.clientOptions,
         disabled: options.disabled,
         proxy: options.proxy,
+        proxyPath: options.proxyPath,
       },
     );
 
@@ -124,10 +133,10 @@ export default defineNuxtModule<ModuleOptions>({
 
       nuxt.options.routeRules = nuxt.options.routeRules || {};
 
-      nuxt.options.routeRules['/ingest/ph/static/**'] = {
+      nuxt.options.routeRules[`${options.proxyPath}/static/**`] = {
         proxy: `https://${region}-assets.i.posthog.com/static/**`,
       };
-      nuxt.options.routeRules['/ingest/ph/**'] = {
+      nuxt.options.routeRules[`${options.proxyPath}/**`] = {
         proxy: `https://${region}.i.posthog.com/**`,
       };
     }

--- a/src/runtime/plugins/posthog.client.ts
+++ b/src/runtime/plugins/posthog.client.ts
@@ -34,7 +34,7 @@ export default defineNuxtPlugin({
       const region = url.hostname.split('.')[0];
 
       clientOptions.ui_host = `https://${region}.posthog.com`;
-      clientOptions.api_host = `${window.location.origin}/ingest/ph`;
+      clientOptions.api_host = `${window.location.origin}${config.proxyPath}`;
     }
 
     const posthogClient = posthog.init(config.publicKey, clientOptions);


### PR DESCRIPTION
I was having issues with the default proxy path getting blocked. I've added an option `proxyPath` to be able to change it.

I'm submitting a PR instead of an issue since I had to fork and modify this for a project anyways.